### PR TITLE
Add missing default copy constructor for DateTime class

### DIFF
--- a/include/trz/engine/internal/time.h
+++ b/include/trz/engine/internal/time.h
@@ -199,7 +199,9 @@ class DateTime : public Time
                                  localMinute(0)
     {
     }
-    
+
+    DateTime(const DateTime&) = default;
+
     DateTime &operator=(const DateTime &t) noexcept
     {
         Time::operator=(t);
@@ -220,7 +222,7 @@ class DateTime : public Time
         localMinute = t.localMinute;
         return *this;
     }
-    
+
     /**
      * @brief Get utc year expressed in unsigned int year
      * @return year in unsigned 32 bytes


### PR DESCRIPTION
This change will fix this compile error:

`[  7%] Building CXX object src/engine/CMakeFiles/engine.dir/home/odeblic/simplx/src/pattern/timer/timeractor.cpp.o
In file included from /home/odeblic/simplx/include/trz/pattern/timer/timeractor.h:10,
                 from /home/odeblic/simplx/src/pattern/timer/timeractor.cpp:8:
/home/odeblic/simplx/include/trz/pattern/timer/timerevent.h: In constructor ‘tredzone::timer::TimeOutEvent::TimeOutEvent(const tredzone::DateTime&)’:
/home/odeblic/simplx/include/trz/pattern/timer/timerevent.h:69:85: error: implicitly-declared ‘tredzone::DateTime::DateTime(const tredzone::DateTime&)’ is deprecated [-Werror=deprecated-copy]
   69 |  inline TimeOutEvent(const DateTime& utcDateTime) noexcept : utcDateTime(utcDateTime) {
      |                                                                                     ^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
make[2]: *** [src/pattern/timer/CMakeFiles/timer.dir/build.make:82 : src/pattern/timer/CMakeFiles/timer.dir/timeractor.cpp.o] Erreur 1
make[1]: *** [CMakeFiles/Makefile2:1313 : src/pattern/timer/CMakeFiles/timer.dir/all] Erreur 2
make[1]: *** Attente des tâches non terminées....
In file included from /home/odeblic/simplx/include/trz/pattern/timer/timeractor.h:10,
                 from /home/odeblic/simplx/src/pattern/timer/timeractor.cpp:8:
/home/odeblic/simplx/include/trz/pattern/timer/timerevent.h: In constructor ‘tredzone::timer::TimeOutEvent::TimeOutEvent(const tredzone::DateTime&)’:
/home/odeblic/simplx/include/trz/pattern/timer/timerevent.h:69:85: error: implicitly-declared ‘tredzone::DateTime::DateTime(const tredzone::DateTime&)’ is deprecated [-Werror=deprecated-copy]
   69 |  inline TimeOutEvent(const DateTime& utcDateTime) noexcept : utcDateTime(utcDateTime) {
      |                                                                                     ^
compilation terminated due to -Wfatal-errors.`